### PR TITLE
Fix database helper initialization in RequestAdapter

### DIFF
--- a/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/RequestAdapter.java
+++ b/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/RequestAdapter.java
@@ -21,7 +21,8 @@ public class RequestAdapter extends BaseAdapter {
     public RequestAdapter(Context context, List<Request> requests, DatabaseHelper db) {
         this.context = context;
         this.requests = requests;
-        this.db = new DatabaseHelper(context); // Crear la instancia de DatabaseHelper
+        // Use the instance provided by the caller instead of creating a new one
+        this.db = db;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- use the provided DatabaseHelper instance in `RequestAdapter`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687075b7467c8321b32829790c01ab7e