### PR TITLE
Add mensajes SMS button to main menu

### DIFF
--- a/ProyectoByS/app/src/main/AndroidManifest.xml
+++ b/ProyectoByS/app/src/main/AndroidManifest.xml
@@ -59,5 +59,6 @@
         <activity android:name=".RemoteSupportListActivity">
             <!-- Nueva actividad para listar servicios con soporte remoto -->
         </activity>
+        <activity android:name=".MensajesSmsActivity" />
     </application>
 </manifest>

--- a/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/MensajesSmsActivity.java
+++ b/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/MensajesSmsActivity.java
@@ -1,0 +1,12 @@
+package com.puropoo.proyectobys;
+
+import android.os.Bundle;
+import androidx.appcompat.app.AppCompatActivity;
+
+public class MensajesSmsActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_mensajes_sms);
+    }
+}

--- a/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/MenuActivity.java
+++ b/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/MenuActivity.java
@@ -13,6 +13,7 @@ public class MenuActivity extends AppCompatActivity {
     Button btnRegisterRequests;  // Nuevo botón para "Registrar Solicitudes"
     Button btnGuardarEquipoAInstalar;  // Nuevo botón para "Guardar Equipo a Instalar"
     Button btnRemoteSupport;  // Nuevo botón para "Soporte Técnico Remoto"
+    Button btnMensajesSms;  // Botón para "Mensajes SMS"
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -29,6 +30,7 @@ public class MenuActivity extends AppCompatActivity {
         btnRegisterRequests = findViewById(R.id.btnRegisterRequests);  // Botón para "Registrar Solicitudes"
         btnGuardarEquipoAInstalar = findViewById(R.id.btnGuardarEquipoAInstalar);  // Botón para "Guardar Equipo a Instalar"
         btnRemoteSupport = findViewById(R.id.btnRemoteSupport);  // Botón para "Soporte Técnico Remoto"
+        btnMensajesSms = findViewById(R.id.btnMensajesSms);  // Botón para "Mensajes SMS"
 
         // Configura el botón de "Registrar Solicitudes"
         btnRegisterRequests.setOnClickListener(v -> {
@@ -78,6 +80,12 @@ public class MenuActivity extends AppCompatActivity {
         // Configura el botón de "Soporte Técnico Remoto"
         btnRemoteSupport.setOnClickListener(v -> {
             Intent intent = new Intent(MenuActivity.this, RemoteSupportActivity.class);
+            startActivity(intent);
+        });
+
+        // Configura el botón de "Mensajes SMS"
+        btnMensajesSms.setOnClickListener(v -> {
+            Intent intent = new Intent(MenuActivity.this, MensajesSmsActivity.class);
             startActivity(intent);
         });
     }

--- a/ProyectoByS/app/src/main/res/layout/activity_mensajes_sms.xml
+++ b/ProyectoByS/app/src/main/res/layout/activity_mensajes_sms.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="24dp"
+    android:background="#FFFFFF">
+
+    <TextView
+        android:text="Pantalla: Mensajes SMS"
+        style="@style/TextAppearance.Title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+</LinearLayout>

--- a/ProyectoByS/app/src/main/res/layout/activity_menu.xml
+++ b/ProyectoByS/app/src/main/res/layout/activity_menu.xml
@@ -98,6 +98,15 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="16dp" />
 
+    <Button
+        android:id="@+id/btnMensajesSms"
+        android:text="MENSAJES SMS"
+        android:background="@drawable/button_border_red"
+        android:textColor="#000000"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp" />
+
     <Spinner
         android:id="@+id/spinnerClients"
         android:layout_width="match_parent"


### PR DESCRIPTION
## Summary
- create `MensajesSmsActivity` and placeholder layout
- expose `MensajesSmsActivity` in manifest
- add `MENSAJES SMS` button to the main menu layout
- wire up the new button in `MenuActivity`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870796491b08321bb63c9d6d7de0291