### PR TITLE
Implement basic SMS notification management

### DIFF
--- a/ProyectoByS/app/src/main/AndroidManifest.xml
+++ b/ProyectoByS/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.puropoo.proyectobys">
 
+    <uses-permission android:name="android.permission.SEND_SMS" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -60,5 +62,6 @@
             <!-- Nueva actividad para listar servicios con soporte remoto -->
         </activity>
         <activity android:name=".MensajesSmsActivity" />
+        <activity android:name=".SmsManagementActivity" />
     </application>
 </manifest>

--- a/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/MensajesSmsActivity.java
+++ b/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/MensajesSmsActivity.java
@@ -1,6 +1,8 @@
 package com.puropoo.proyectobys;
 
+import android.content.Intent;
 import android.os.Bundle;
+import android.widget.Button;
 import androidx.appcompat.app.AppCompatActivity;
 
 public class MensajesSmsActivity extends AppCompatActivity {
@@ -8,5 +10,18 @@ public class MensajesSmsActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_mensajes_sms);
+        Button btnEquipo = findViewById(R.id.btnEquipoTecnico);
+        Button btnTecnico = findViewById(R.id.btnTecnico);
+        Button btnCliente = findViewById(R.id.btnCliente);
+
+        btnEquipo.setOnClickListener(v -> openManagement("tecnico"));
+        btnTecnico.setOnClickListener(v -> openManagement("tecnico"));
+        btnCliente.setOnClickListener(v -> openManagement("cliente"));
+    }
+
+    private void openManagement(String type) {
+        Intent intent = new Intent(this, SmsManagementActivity.class);
+        intent.putExtra("recipientType", type);
+        startActivity(intent);
     }
 }

--- a/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/MenuActivity.java
+++ b/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/MenuActivity.java
@@ -4,6 +4,8 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
+
+import com.puropoo.proyectobys.SmsUtils;
 import androidx.appcompat.app.AppCompatActivity;
 
 public class MenuActivity extends AppCompatActivity {
@@ -19,6 +21,7 @@ public class MenuActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_menu);
+        SmsUtils.checkAndSendPendingSms(this);
 
         // Inicialización de botones
         btnRegisterClient = findViewById(R.id.btnRegisterClient);

--- a/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/RegisterRequestActivity.java
+++ b/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/RegisterRequestActivity.java
@@ -16,6 +16,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.ArrayList;
 
+import com.puropoo.proyectobys.SmsUtils;
+
 public class RegisterRequestActivity extends AppCompatActivity {
 
     Spinner spinnerClients, spinnerServiceType;
@@ -97,6 +99,8 @@ public class RegisterRequestActivity extends AppCompatActivity {
         long id = db.insertRequest(serviceType, serviceDate, serviceTime, clientCedula, newServiceAddress);
         if (id != -1) {
             Toast.makeText(this, "Solicitud guardada correctamente", Toast.LENGTH_LONG).show();
+            Request request = new Request((int) id, serviceType, serviceDate, serviceTime, newServiceAddress, clientCedula);
+            SmsUtils.scheduleSmsForRequest(this, request);
         } else {
             Toast.makeText(this, "Ya existe una solicitud para este cliente en esta fecha y hora", Toast.LENGTH_LONG).show();
         }

--- a/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/SQLiteHelper.java
+++ b/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/SQLiteHelper.java
@@ -9,7 +9,7 @@ public class SQLiteHelper extends SQLiteOpenHelper {
 
     // Definir el nombre y la versión de la base de datos
     private static final String DATABASE_NAME = "service_db";
-    private static final int DATABASE_VERSION = 4;
+    private static final int DATABASE_VERSION = 5;
     
     // Definir constante SQL para crear la tabla equipo_instalar
     private static final String CREATE_EQUIPO_INSTALAR_TABLE = "CREATE TABLE IF NOT EXISTS equipo_instalar (" +
@@ -36,6 +36,19 @@ public class SQLiteHelper extends SQLiteOpenHelper {
             "medium TEXT, " +
             "link TEXT, " +
             "client_cedula TEXT)";
+
+    // Tabla para notificaciones SMS
+    private static final String CREATE_SMS_NOTIFICATION_TABLE = "CREATE TABLE IF NOT EXISTS sms_notifications (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            "request_id INTEGER, " +
+            "recipient_type TEXT, " +
+            "phone TEXT, " +
+            "service_date TEXT, " +
+            "service_time TEXT, " +
+            "service_type TEXT, " +
+            "message TEXT, " +
+            "scheduled_send TEXT, " +
+            "sent_time TEXT)";
 
     public SQLiteHelper(Context context) {
         super(context, DATABASE_NAME, null, DATABASE_VERSION);
@@ -90,6 +103,9 @@ public class SQLiteHelper extends SQLiteOpenHelper {
         // Crear la tabla 'remote_support'
         db.execSQL(CREATE_REMOTE_SUPPORT_TABLE);
 
+        // Crear tabla para notificaciones SMS
+        db.execSQL(CREATE_SMS_NOTIFICATION_TABLE);
+
     }
 
     // Método para actualizar la base de datos
@@ -112,6 +128,11 @@ public class SQLiteHelper extends SQLiteOpenHelper {
         if (oldVersion < 4) {
             // Crear la tabla 'remote_support' para la actualización de versión 3 a 4
             db.execSQL(CREATE_REMOTE_SUPPORT_TABLE);
+        }
+
+        // Manejar la actualización de versión 4 a 5
+        if (oldVersion < 5) {
+            db.execSQL(CREATE_SMS_NOTIFICATION_TABLE);
         }
     }
 

--- a/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/SmsManagementActivity.java
+++ b/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/SmsManagementActivity.java
@@ -1,0 +1,83 @@
+package com.puropoo.proyectobys;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.ListView;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SmsManagementActivity extends AppCompatActivity {
+
+    private Button btnSmsSent, btnSmsPending;
+    private ListView lvSms;
+    private DatabaseHelper db;
+    private String recipientType;
+    private List<SmsNotification> currentList = new ArrayList<>();
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_sms_management);
+
+        btnSmsSent = findViewById(R.id.btnSmsSent);
+        btnSmsPending = findViewById(R.id.btnSmsPending);
+        lvSms = findViewById(R.id.lvSms);
+
+        recipientType = getIntent().getStringExtra("recipientType");
+        db = new DatabaseHelper(this);
+
+        btnSmsSent.setOnClickListener(v -> loadSms(true));
+        btnSmsPending.setOnClickListener(v -> loadSms(false));
+
+        lvSms.setOnItemClickListener((parent, view, position, id) -> {
+            SmsNotification sms = currentList.get(position);
+            if (sms.getSentTime() == null) {
+                showInstructionDialog(sms);
+            }
+        });
+
+        loadSms(false);
+    }
+
+    private void loadSms(boolean sent) {
+        currentList = db.getSmsNotifications(recipientType, sent);
+        List<String> display = new ArrayList<>();
+        for (SmsNotification sms : currentList) {
+            String text;
+            if (sent) {
+                text = "Enviado: " + sms.getSentTime() + " - Servicio: " + sms.getServiceType() + " " + sms.getServiceDate() + " " + sms.getServiceTime();
+            } else {
+                text = "Programado: " + sms.getScheduledSend() + " - Servicio: " + sms.getServiceType() + " " + sms.getServiceDate() + " " + sms.getServiceTime();
+            }
+            display.add(text);
+        }
+        lvSms.setAdapter(new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, display));
+    }
+
+    private void showInstructionDialog(SmsNotification sms) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setTitle("Agregar instrucciones");
+        final EditText input = new EditText(this);
+        input.setText(sms.getMessage());
+        builder.setView(input);
+        builder.setPositiveButton("Guardar", (dialog, which) -> {
+            String msg = input.getText().toString();
+            db.updateSmsMessage(sms.getId(), msg);
+            loadSms(false);
+        });
+        builder.setNegativeButton("Cancelar", null);
+        builder.show();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        SmsUtils.checkAndSendPendingSms(this);
+    }
+}

--- a/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/SmsNotification.java
+++ b/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/SmsNotification.java
@@ -1,0 +1,56 @@
+package com.puropoo.proyectobys;
+
+public class SmsNotification {
+    private int id;
+    private int requestId;
+    private String recipientType;
+    private String phone;
+    private String serviceDate;
+    private String serviceTime;
+    private String serviceType;
+    private String message;
+    private String scheduledSend;
+    private String sentTime;
+
+    public SmsNotification(int id, int requestId, String recipientType, String phone,
+                           String serviceDate, String serviceTime, String serviceType,
+                           String message, String scheduledSend, String sentTime) {
+        this.id = id;
+        this.requestId = requestId;
+        this.recipientType = recipientType;
+        this.phone = phone;
+        this.serviceDate = serviceDate;
+        this.serviceTime = serviceTime;
+        this.serviceType = serviceType;
+        this.message = message;
+        this.scheduledSend = scheduledSend;
+        this.sentTime = sentTime;
+    }
+
+    public SmsNotification(int requestId, String recipientType, String phone,
+                           String serviceDate, String serviceTime, String serviceType,
+                           String message, String scheduledSend) {
+        this.requestId = requestId;
+        this.recipientType = recipientType;
+        this.phone = phone;
+        this.serviceDate = serviceDate;
+        this.serviceTime = serviceTime;
+        this.serviceType = serviceType;
+        this.message = message;
+        this.scheduledSend = scheduledSend;
+    }
+
+    public int getId() { return id; }
+    public int getRequestId() { return requestId; }
+    public String getRecipientType() { return recipientType; }
+    public String getPhone() { return phone; }
+    public String getServiceDate() { return serviceDate; }
+    public String getServiceTime() { return serviceTime; }
+    public String getServiceType() { return serviceType; }
+    public String getMessage() { return message; }
+    public String getScheduledSend() { return scheduledSend; }
+    public String getSentTime() { return sentTime; }
+
+    public void setMessage(String message) { this.message = message; }
+    public void setSentTime(String sentTime) { this.sentTime = sentTime; }
+}

--- a/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/SmsUtils.java
+++ b/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/SmsUtils.java
@@ -1,0 +1,85 @@
+package com.puropoo.proyectobys;
+
+import android.content.Context;
+import android.telephony.SmsManager;
+import android.util.Log;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+
+public class SmsUtils {
+    private static final String TAG = "SmsUtils";
+
+    // Crear notificaciones para un servicio
+    public static void scheduleSmsForRequest(Context ctx, Request request) {
+        DatabaseHelper db = new DatabaseHelper(ctx);
+        List<String> teamPhones = db.getAllTeamPhones();
+        Client client = db.getClientByCedula(request.getClientCedula());
+
+        String baseMessage = "Servicio " + request.getServiceType() + " el " +
+                request.getServiceDate() + " a las " + request.getServiceTime();
+
+        String scheduled = calculateScheduledTime(request.getServiceDate(), request.getServiceTime());
+
+        for (String phone : teamPhones) {
+            SmsNotification sms = new SmsNotification(
+                    request.getId(),
+                    "tecnico",
+                    phone,
+                    request.getServiceDate(),
+                    request.getServiceTime(),
+                    request.getServiceType(),
+                    baseMessage,
+                    scheduled
+            );
+            db.insertSmsNotification(sms);
+        }
+
+        if (client != null) {
+            SmsNotification sms = new SmsNotification(
+                    request.getId(),
+                    "cliente",
+                    client.phone,
+                    request.getServiceDate(),
+                    request.getServiceTime(),
+                    request.getServiceType(),
+                    baseMessage,
+                    scheduled
+            );
+            db.insertSmsNotification(sms);
+        }
+    }
+
+    private static String calculateScheduledTime(String serviceDate, String serviceTime) {
+        try {
+            SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy HH:mm");
+            Date date = sdf.parse(serviceDate + " " + serviceTime);
+            Calendar cal = Calendar.getInstance();
+            cal.setTime(date);
+            cal.add(Calendar.HOUR_OF_DAY, -24);
+            SimpleDateFormat out = new SimpleDateFormat("yyyy-MM-dd HH:mm");
+            return out.format(cal.getTime());
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    public static void checkAndSendPendingSms(Context ctx) {
+        DatabaseHelper db = new DatabaseHelper(ctx);
+        String now = new SimpleDateFormat("yyyy-MM-dd HH:mm").format(new Date());
+        List<SmsNotification> pending = db.getPendingSmsDue(now);
+        SmsManager smsManager = SmsManager.getDefault();
+        for (SmsNotification sms : pending) {
+            try {
+                smsManager.sendTextMessage(sms.getPhone(), null, sms.getMessage(), null, null);
+                String sentTime = new SimpleDateFormat("yyyy-MM-dd HH:mm").format(new Date());
+                db.markSmsAsSent(sms.getId(), sentTime);
+                Log.d(TAG, "SMS enviado a " + sms.getPhone());
+            } catch (Exception e) {
+                Log.e(TAG, "Error enviando SMS", e);
+            }
+        }
+    }
+}

--- a/ProyectoByS/app/src/main/res/layout/activity_mensajes_sms.xml
+++ b/ProyectoByS/app/src/main/res/layout/activity_mensajes_sms.xml
@@ -8,8 +8,29 @@
     android:background="#FFFFFF">
 
     <TextView
-        android:text="Pantalla: Mensajes SMS"
+        android:text="Mensajes SMS"
         style="@style/TextAppearance.Title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"/>
+
+    <Button
+        android:id="@+id/btnEquipoTecnico"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Equipo Técnico"
+        android:layout_marginTop="24dp" />
+
+    <Button
+        android:id="@+id/btnTecnico"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Técnico"
+        android:layout_marginTop="16dp" />
+
+    <Button
+        android:id="@+id/btnCliente"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Cliente"
+        android:layout_marginTop="16dp" />
 </LinearLayout>

--- a/ProyectoByS/app/src/main/res/layout/activity_sms_management.xml
+++ b/ProyectoByS/app/src/main/res/layout/activity_sms_management.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="24dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Button
+        android:id="@+id/btnSmsSent"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="SMS Enviados" />
+
+    <Button
+        android:id="@+id/btnSmsPending"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="SMS Por Enviar"
+        android:layout_marginTop="16dp" />
+
+    <ListView
+        android:id="@+id/lvSms"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp" />
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- set up `SmsNotification` model and utilities
- create tables for SMS notifications in SQLite helper
- schedule SMS when requests are created
- add management UI with activities and layouts
- request SEND_SMS permission in manifest

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68709854ffe8832190387b1e03f3f177