### PR TITLE
Load real technical services in remote support spinner

### DIFF
--- a/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/DatabaseHelper.java
+++ b/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/DatabaseHelper.java
@@ -445,19 +445,21 @@ public class DatabaseHelper {
         List<Request> list = new ArrayList<>();
         SQLiteDatabase db = helper.getReadableDatabase();
         
-        // Obtener fecha actual en formato yyyy-MM-dd
-        java.text.SimpleDateFormat sdf = new java.text.SimpleDateFormat("yyyy-MM-dd");
+        // Obtener fecha actual en formato dd/MM/yyyy (mismo formato que se almacena en la base de datos)
+        java.text.SimpleDateFormat sdf = new java.text.SimpleDateFormat("dd/MM/yyyy");
         String today = sdf.format(new java.util.Date());
-        
+
+        // Comparar las fechas convirtiendo el formato dd/MM/yyyy a yyyy-MM-dd dentro de la consulta
         String query = "SELECT id, serviceType, serviceDate, serviceTime, clientCedula, serviceAddress " +
                        "FROM requests WHERE (LOWER(serviceType) LIKE LOWER('%mantenimiento%') OR " +
                        "LOWER(serviceType) LIKE LOWER('%reparac%') OR " +
                        "LOWER(serviceType) LIKE LOWER('%técnic%') OR " +
                        "LOWER(serviceType) LIKE LOWER('%tecnic%')) AND " +
-                       "serviceDate >= ? " +
+                       "DATE(substr(serviceDate, 7, 4) || '-' || substr(serviceDate, 4, 2) || '-' || substr(serviceDate, 1, 2)) >= " +
+                       "DATE(substr(?, 7, 4) || '-' || substr(?, 4, 2) || '-' || substr(?, 1, 2)) " +
                        "ORDER BY serviceDate, serviceTime";
-        
-        Cursor c = db.rawQuery(query, new String[]{today});
+
+        Cursor c = db.rawQuery(query, new String[]{today, today, today});
 
         while (c.moveToNext()) {
             Request request = new Request(

--- a/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/RemoteSupportActivity.java
+++ b/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/RemoteSupportActivity.java
@@ -8,7 +8,6 @@ import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Spinner;
-import android.widget.TextView;
 import android.widget.Toast;
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -59,10 +58,11 @@ public class RemoteSupportActivity extends AppCompatActivity {
 
     private void loadTechnicalServices() {
         technicalServices = db.getFutureTechnicalServices();
-        
-        if (technicalServices.isEmpty()) {
-            // Si no hay servicios, agregar datos dummy para demostración
-            loadDummyData();
+
+        if (technicalServices == null || technicalServices.isEmpty()) {
+            Toast.makeText(this, "No hay servicios técnicos registrados", Toast.LENGTH_LONG).show();
+            finish();
+            return;
         }
 
         // Crear lista de strings para el spinner
@@ -95,18 +95,6 @@ public class RemoteSupportActivity extends AppCompatActivity {
         spinnerTechnicalServices.setAdapter(adapter);
     }
 
-    private void loadDummyData() {
-        // Agregar algunos datos dummy para demostración
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
-        String futureDate1 = "2024-12-20";
-        String futureDate2 = "2024-12-25";
-        
-        Request dummyRequest1 = new Request(999, "Mantenimiento Preventivo", futureDate1, "10:00", "Dirección 123", "12345678");
-        Request dummyRequest2 = new Request(998, "Reparación Técnica", futureDate2, "14:30", "Dirección 456", "87654321");
-        
-        technicalServices.add(dummyRequest1);
-        technicalServices.add(dummyRequest2);
-    }
 
     private void setupListeners() {
         // Listener para el spinner


### PR DESCRIPTION
## Summary
- fetch technical services from `DatabaseHelper` in `RemoteSupportActivity`
- remove dummy data and unused import
- fix technical services query to correctly compare dates in dd/MM/yyyy format

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871bf2631b883218f0c4bd8b000eaf6