### PR TITLE
Load real installation requests in remote support spinner

### DIFF
--- a/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/DatabaseHelper.java
+++ b/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/DatabaseHelper.java
@@ -363,21 +363,22 @@ public class DatabaseHelper {
     public List<Request> getUpcomingInstallRequests() {
         List<Request> list = new ArrayList<>();
         SQLiteDatabase db = helper.getReadableDatabase();
-        
-        // Obtener fecha actual en formato yyyy-MM-dd
-        java.text.SimpleDateFormat sdf = new java.text.SimpleDateFormat("yyyy-MM-dd");
+
+        // Obtener fecha actual en formato dd/MM/yyyy (mismo formato que se almacena)
+        java.text.SimpleDateFormat sdf = new java.text.SimpleDateFormat("dd/MM/yyyy");
         String today = sdf.format(new java.util.Date());
-        
-        // Make the query more flexible - look for any service type containing "install" (case-insensitive)
+
+        // Buscar solicitudes de instalación (incluyendo posibles variaciones de la palabra)
         String query = "SELECT id, serviceType, serviceDate, serviceTime, clientCedula, serviceAddress " +
-                       "FROM requests WHERE (LOWER(serviceType) LIKE '%install%' OR LOWER(serviceType) LIKE '%instalac%') AND " +
-                       "serviceDate >= ? " +
-                       "ORDER BY serviceDate, serviceTime";
-        
+                       "FROM requests WHERE LOWER(serviceType) LIKE LOWER('%instal%') AND " +
+                       "DATE(substr(serviceDate, 7, 4) || '-' || substr(serviceDate, 4, 2) || '-' || substr(serviceDate, 1, 2)) >= " +
+                       "DATE(substr(?, 7, 4) || '-' || substr(?, 4, 2) || '-' || substr(?, 1, 2)) " +
+                       "ORDER BY serviceDate, serviceTime"; 
+
         android.util.Log.d("DatabaseHelper", "Query: " + query);
         android.util.Log.d("DatabaseHelper", "Today: " + today);
-        
-        Cursor c = db.rawQuery(query, new String[]{today});
+
+        Cursor c = db.rawQuery(query, new String[]{today, today, today});
         android.util.Log.d("DatabaseHelper", "Cursor count: " + c.getCount());
 
         while (c.moveToNext()) {
@@ -445,19 +446,21 @@ public class DatabaseHelper {
         List<Request> list = new ArrayList<>();
         SQLiteDatabase db = helper.getReadableDatabase();
         
-        // Obtener fecha actual en formato yyyy-MM-dd
-        java.text.SimpleDateFormat sdf = new java.text.SimpleDateFormat("yyyy-MM-dd");
+        // Obtener fecha actual en formato dd/MM/yyyy (mismo formato que se almacena en la base de datos)
+        java.text.SimpleDateFormat sdf = new java.text.SimpleDateFormat("dd/MM/yyyy");
         String today = sdf.format(new java.util.Date());
-        
+
+        // Comparar las fechas convirtiendo el formato dd/MM/yyyy a yyyy-MM-dd dentro de la consulta
         String query = "SELECT id, serviceType, serviceDate, serviceTime, clientCedula, serviceAddress " +
                        "FROM requests WHERE (LOWER(serviceType) LIKE LOWER('%mantenimiento%') OR " +
                        "LOWER(serviceType) LIKE LOWER('%reparac%') OR " +
                        "LOWER(serviceType) LIKE LOWER('%técnic%') OR " +
                        "LOWER(serviceType) LIKE LOWER('%tecnic%')) AND " +
-                       "serviceDate >= ? " +
+                       "DATE(substr(serviceDate, 7, 4) || '-' || substr(serviceDate, 4, 2) || '-' || substr(serviceDate, 1, 2)) >= " +
+                       "DATE(substr(?, 7, 4) || '-' || substr(?, 4, 2) || '-' || substr(?, 1, 2)) " +
                        "ORDER BY serviceDate, serviceTime";
-        
-        Cursor c = db.rawQuery(query, new String[]{today});
+
+        Cursor c = db.rawQuery(query, new String[]{today, today, today});
 
         while (c.moveToNext()) {
             Request request = new Request(

--- a/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/GuardarEquipoAInstalarActivity.java
+++ b/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/GuardarEquipoAInstalarActivity.java
@@ -55,16 +55,6 @@ public class GuardarEquipoAInstalarActivity extends AppCompatActivity {
     private void loadInstallationServices() {
         Log.d(TAG, "Loading installation services...");
         
-        // First, let's check all requests to debug the issue
-        List<Request> allRequests = db.getAllRequests();
-        Log.d(TAG, "Total requests in database: " + allRequests.size());
-        
-        for (Request request : allRequests) {
-            Log.d(TAG, "Request: ID=" + request.getId() + ", ServiceType=" + request.getServiceType() + 
-                  ", Date=" + request.getServiceDate() + ", Time=" + request.getServiceTime() + 
-                  ", Client=" + request.getClientCedula());
-        }
-        
         installationRequests = db.getUpcomingInstallRequests();
         Log.d(TAG, "Installation requests found: " + installationRequests.size());
         
@@ -79,24 +69,13 @@ public class GuardarEquipoAInstalarActivity extends AppCompatActivity {
         tvNoServicesMessage.setVisibility(View.GONE);
         spinnerServices.setVisibility(View.VISIBLE);
 
-        // Crear lista de strings para el spinner con formato "cedula - dd/MM/yyyy - HH:mm"
+        // Crear lista de strings para el spinner
         List<String> spinnerItems = new ArrayList<>();
-        SimpleDateFormat inputFormat = new SimpleDateFormat("yyyy-MM-dd");
-        SimpleDateFormat outputFormat = new SimpleDateFormat("dd/MM/yyyy");
+        spinnerItems.add("Seleccione un servicio");
         
         for (Request request : installationRequests) {
             String formattedDate = request.getServiceDate();
-            
-            // Convertir fecha de yyyy-MM-dd a dd/MM/yyyy
-            try {
-                Date date = inputFormat.parse(request.getServiceDate());
-                formattedDate = outputFormat.format(date);
-            } catch (ParseException e) {
-                // Si no se puede parsear, usar la fecha original
-                formattedDate = request.getServiceDate();
-            }
-            
-            String item = request.getClientCedula() + " - " + formattedDate + " - " + request.getServiceTime();
+            String item = request.getId() + " - " + formattedDate + " - " + request.getServiceTime();
             spinnerItems.add(item);
             Log.d(TAG, "Added spinner item: " + item);
         }
@@ -113,8 +92,8 @@ public class GuardarEquipoAInstalarActivity extends AppCompatActivity {
         spinnerServices.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override
             public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-                if (position >= 0 && position < installationRequests.size()) {
-                    Request selectedRequest = installationRequests.get(position);
+                if (position > 0) { // Ignorar la opción por defecto
+                    Request selectedRequest = installationRequests.get(position - 1);
                     selectedRequestId = selectedRequest.getId();
                     
                     // Verificar si ya existe equipo para esta solicitud
@@ -191,8 +170,8 @@ public class GuardarEquipoAInstalarActivity extends AppCompatActivity {
 
     private Request getSelectedRequest() {
         int selectedPosition = spinnerServices.getSelectedItemPosition();
-        if (selectedPosition >= 0 && selectedPosition < installationRequests.size()) {
-            return installationRequests.get(selectedPosition);
+        if (selectedPosition > 0 && selectedPosition - 1 < installationRequests.size()) {
+            return installationRequests.get(selectedPosition - 1);
         }
         return null;
     }

--- a/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/RemoteSupportActivity.java
+++ b/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/RemoteSupportActivity.java
@@ -1,6 +1,5 @@
 package com.puropoo.proyectobys;
 
-import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.AdapterView;
@@ -8,7 +7,6 @@ import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Spinner;
-import android.widget.TextView;
 import android.widget.Toast;
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -24,7 +22,6 @@ public class RemoteSupportActivity extends AppCompatActivity {
     private EditText etMedio;
     private EditText etLink;
     private Button btnSave;
-    private Button btnViewRemoteServices;
 
     private DatabaseHelper db;
     private List<Request> technicalServices;
@@ -54,15 +51,15 @@ public class RemoteSupportActivity extends AppCompatActivity {
         etMedio = findViewById(R.id.etMedio);
         etLink = findViewById(R.id.etLink);
         btnSave = findViewById(R.id.btnSave);
-        btnViewRemoteServices = findViewById(R.id.btnViewRemoteServices);
     }
 
     private void loadTechnicalServices() {
         technicalServices = db.getFutureTechnicalServices();
-        
-        if (technicalServices.isEmpty()) {
-            // Si no hay servicios, agregar datos dummy para demostración
-            loadDummyData();
+
+        if (technicalServices == null || technicalServices.isEmpty()) {
+            Toast.makeText(this, "No hay servicios técnicos registrados", Toast.LENGTH_LONG).show();
+            finish();
+            return;
         }
 
         // Crear lista de strings para el spinner
@@ -95,18 +92,6 @@ public class RemoteSupportActivity extends AppCompatActivity {
         spinnerTechnicalServices.setAdapter(adapter);
     }
 
-    private void loadDummyData() {
-        // Agregar algunos datos dummy para demostración
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
-        String futureDate1 = "2024-12-20";
-        String futureDate2 = "2024-12-25";
-        
-        Request dummyRequest1 = new Request(999, "Mantenimiento Preventivo", futureDate1, "10:00", "Dirección 123", "12345678");
-        Request dummyRequest2 = new Request(998, "Reparación Técnica", futureDate2, "14:30", "Dirección 456", "87654321");
-        
-        technicalServices.add(dummyRequest1);
-        technicalServices.add(dummyRequest2);
-    }
 
     private void setupListeners() {
         // Listener para el spinner
@@ -132,11 +117,6 @@ public class RemoteSupportActivity extends AppCompatActivity {
         // Listener para el botón guardar
         btnSave.setOnClickListener(v -> saveRemoteSupport());
         
-        // Listener para el botón ver servicios remotos
-        btnViewRemoteServices.setOnClickListener(v -> {
-            Intent intent = new Intent(RemoteSupportActivity.this, RemoteSupportListActivity.class);
-            startActivity(intent);
-        });
     }
 
     private void loadExistingRemoteSupport() {

--- a/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/SmsManagementActivity.java
+++ b/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/SmsManagementActivity.java
@@ -51,9 +51,15 @@ public class SmsManagementActivity extends AppCompatActivity {
         for (SmsNotification sms : currentList) {
             String text;
             if (sent) {
-                text = "Enviado: " + sms.getSentTime() + " - Servicio: " + sms.getServiceType() + " " + sms.getServiceDate() + " " + sms.getServiceTime();
+                text = "Enviado: " + sms.getSentTime()
+                        + " a " + sms.getPhone()
+                        + " - Servicio: " + sms.getServiceType()
+                        + " " + sms.getServiceDate() + " " + sms.getServiceTime();
             } else {
-                text = "Programado: " + sms.getScheduledSend() + " - Servicio: " + sms.getServiceType() + " " + sms.getServiceDate() + " " + sms.getServiceTime();
+                text = "Programado: " + sms.getScheduledSend()
+                        + " a " + sms.getPhone()
+                        + " - Servicio: " + sms.getServiceType()
+                        + " " + sms.getServiceDate() + " " + sms.getServiceTime();
             }
             display.add(text);
         }
@@ -63,6 +69,7 @@ public class SmsManagementActivity extends AppCompatActivity {
     private void showInstructionDialog(SmsNotification sms) {
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
         builder.setTitle("Agregar instrucciones");
+        builder.setMessage("Tel\u00e9fono: " + sms.getPhone());
         final EditText input = new EditText(this);
         input.setText(sms.getMessage());
         builder.setView(input);

--- a/ProyectoByS/app/src/main/res/drawable/edittext_border_red.xml
+++ b/ProyectoByS/app/src/main/res/drawable/edittext_border_red.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Base background with red border and a thin gradient line at the bottom.
+    The line goes from near white on the left to the same red used for the
+    button borders on the right.
+-->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Base background with rounded red border -->
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="#FFFFFF"/>
+            <stroke android:width="1dp" android:color="#BD3F3F"/>
+            <corners android:radius="8dp"/>
+        </shape>
+    </item>
+
+    <!-- Gradient underline -->
+    <item android:gravity="bottom">
+        <shape android:shape="rectangle">
+            <size android:height="2dp"/>
+            <gradient android:startColor="#FFF5F5"
+                      android:endColor="#BD3F3F"
+                      android:angle="0"/>
+        </shape>
+    </item>
+</layer-list>

--- a/ProyectoByS/app/src/main/res/layout/activity_remote_support.xml
+++ b/ProyectoByS/app/src/main/res/layout/activity_remote_support.xml
@@ -3,8 +3,9 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="16dp"
-    android:background="#FFFFFF">
+    android:padding="24dp"
+    android:background="#FFFFFF"
+    android:gravity="center_horizontal">
 
     <TextView
         android:text="Registrar Soporte Técnico Remoto"
@@ -25,6 +26,8 @@
         android:id="@+id/spinnerTechnicalServices"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="@drawable/button_border_red"
+        android:padding="12dp"
         android:layout_marginBottom="24dp"/>
 
     <TextView
@@ -41,6 +44,8 @@
         android:hint="Ej: Zoom, Meet, WhatsApp, etc."
         style="@style/TextAppearance.Body"
         android:inputType="text"
+        android:background="@drawable/edittext_border_red"
+        android:padding="12dp"
         android:layout_marginBottom="16dp"/>
 
     <TextView
@@ -57,23 +62,18 @@
         android:hint="Enlace del medio de comunicación"
         style="@style/TextAppearance.Body"
         android:inputType="textUri"
+        android:background="@drawable/edittext_border_red"
+        android:padding="12dp"
         android:layout_marginBottom="24dp"/>
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/btnSave"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Guardar"
         android:background="@drawable/button_border_red"
         android:textColor="#000000"
+        android:padding="12dp"
         android:layout_marginBottom="16dp"/>
-
-    <Button
-        android:id="@+id/btnViewRemoteServices"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="Ver Servicios con Soporte Remoto"
-        android:background="@drawable/button_border_red"
-        android:textColor="#000000"/>
 
 </LinearLayout>


### PR DESCRIPTION
## Summary
- fetch only upcoming installation requests in database using date-aware query
- populate installation spinner with real requests and a default prompt
- show SMS phone numbers in pending/sent message lists and dialogs
- modernize remote support layout with improved spacing and Material styles
- add gradient underline to red bordered text fields

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871bf2631b883218f0c4bd8b000eaf6