### PR TITLE
Simplify team management flow

### DIFF
--- a/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/DatabaseHelper.java
+++ b/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/DatabaseHelper.java
@@ -278,6 +278,50 @@ public class DatabaseHelper {
         db.close();
         return hasTeamAssigned;
     }
+
+    // Insertar miembro del equipo asociado a una solicitud
+    public long insertTeamMemberForRequest(TeamMember member) {
+        SQLiteDatabase db = helper.getWritableDatabase();
+        ContentValues values = new ContentValues();
+        values.put("request_id", member.getRequestId());
+        values.put("technician_name", member.getName());
+        values.put("technician_role", member.getRole());
+        values.put("technician_phone", member.getPhone());
+        values.put("technician_age", member.getAge());
+        values.put("technician_payment", member.getPayment());
+        long id = db.insert("team", null, values);
+        db.close();
+        return id;
+    }
+
+    // Obtener miembros del equipo por solicitud
+    public List<TeamMember> getTeamMembersForRequest(int requestId) {
+        List<TeamMember> list = new ArrayList<>();
+        SQLiteDatabase db = helper.getReadableDatabase();
+        Cursor cursor = db.rawQuery("SELECT * FROM team WHERE request_id = ?", new String[]{String.valueOf(requestId)});
+        while (cursor.moveToNext()) {
+            TeamMember m = new TeamMember(
+                    cursor.getInt(cursor.getColumnIndex("id")),
+                    requestId,
+                    cursor.getString(cursor.getColumnIndex("technician_name")),
+                    cursor.getString(cursor.getColumnIndex("technician_role")),
+                    cursor.getString(cursor.getColumnIndex("technician_phone")),
+                    cursor.getInt(cursor.getColumnIndex("technician_age")),
+                    cursor.getDouble(cursor.getColumnIndex("technician_payment"))
+            );
+            list.add(m);
+        }
+        cursor.close();
+        db.close();
+        return list;
+    }
+
+    // Eliminar miembros del equipo de una solicitud
+    public void deleteTeamMembersForRequest(int requestId) {
+        SQLiteDatabase db = helper.getWritableDatabase();
+        db.delete("team", "request_id = ?", new String[]{String.valueOf(requestId)});
+        db.close();
+    }
     public boolean insertMaintenanceRequirements(String serviceName, String requirements) {
         SQLiteDatabase db = helper.getWritableDatabase();
         ContentValues values = new ContentValues();

--- a/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/SQLiteHelper.java
+++ b/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/SQLiteHelper.java
@@ -9,7 +9,7 @@ public class SQLiteHelper extends SQLiteOpenHelper {
 
     // Definir el nombre y la versión de la base de datos
     private static final String DATABASE_NAME = "service_db";
-    private static final int DATABASE_VERSION = 5;
+    private static final int DATABASE_VERSION = 6;
     
     // Definir constante SQL para crear la tabla equipo_instalar
     private static final String CREATE_EQUIPO_INSTALAR_TABLE = "CREATE TABLE IF NOT EXISTS equipo_instalar (" +
@@ -82,10 +82,12 @@ public class SQLiteHelper extends SQLiteOpenHelper {
         // Crear tabla 'team' (falta esta tabla)
         db.execSQL("CREATE TABLE IF NOT EXISTS team (" +
                 "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
-                "request_id INTEGER, " + // Relación con la solicitud
+                "request_id INTEGER, " +
                 "technician_name TEXT, " +
                 "technician_role TEXT, " +
-                "technician_phone TEXT);");
+                "technician_phone TEXT, " +
+                "technician_age INTEGER, " +
+                "technician_payment REAL);");
 
         // Crear la tabla 'maintenance_requirements'
         String CREATE_MAINTENANCE_REQUIREMENTS_TABLE = "CREATE TABLE IF NOT EXISTS maintenance_requirements (" +
@@ -133,6 +135,18 @@ public class SQLiteHelper extends SQLiteOpenHelper {
         // Manejar la actualización de versión 4 a 5
         if (oldVersion < 5) {
             db.execSQL(CREATE_SMS_NOTIFICATION_TABLE);
+        }
+
+        if (oldVersion < 6) {
+            db.execSQL("DROP TABLE IF EXISTS team");
+            db.execSQL("CREATE TABLE IF NOT EXISTS team (" +
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                    "request_id INTEGER, " +
+                    "technician_name TEXT, " +
+                    "technician_role TEXT, " +
+                    "technician_phone TEXT, " +
+                    "technician_age INTEGER, " +
+                    "technician_payment REAL);");
         }
     }
 

--- a/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/TeamMember.java
+++ b/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/TeamMember.java
@@ -1,0 +1,33 @@
+package com.puropoo.proyectobys;
+
+public class TeamMember {
+    private int id;
+    private int requestId;
+    private String name;
+    private String role;
+    private String phone;
+    private int age;
+    private double payment;
+
+    public TeamMember(int id, int requestId, String name, String role, String phone, int age, double payment) {
+        this.id = id;
+        this.requestId = requestId;
+        this.name = name;
+        this.role = role;
+        this.phone = phone;
+        this.age = age;
+        this.payment = payment;
+    }
+
+    public TeamMember(int requestId, String name, String role, String phone, int age, double payment) {
+        this(0, requestId, name, role, phone, age, payment);
+    }
+
+    public int getId() { return id; }
+    public int getRequestId() { return requestId; }
+    public String getName() { return name; }
+    public String getRole() { return role; }
+    public String getPhone() { return phone; }
+    public int getAge() { return age; }
+    public double getPayment() { return payment; }
+}

--- a/ProyectoByS/app/src/main/res/layout/activity_register_team.xml
+++ b/ProyectoByS/app/src/main/res/layout/activity_register_team.xml
@@ -21,19 +21,10 @@
         android:layout_marginTop="16dp" />
 
     <Button
-        android:id="@+id/btnRegisterMembers"
+        android:id="@+id/btnManageMembers"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Registrar Integrantes"
-        android:background="@drawable/button_border_red"
-        android:textColor="#000000"
-        android:layout_marginTop="16dp"/>
-
-    <Button
-        android:id="@+id/btnSaveTeam"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="Guardar equipo"
         android:background="@drawable/button_border_red"
         android:textColor="#000000"
         android:layout_marginTop="16dp"/>


### PR DESCRIPTION
## Summary
- add TeamMember model
- store full team info in `team` table and bump DB version
- add CRUD helpers for team members
- streamline RegisterTeamActivity with single manage button
- allow editing existing team members in RegisterMembersActivity

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872002eb4748321aa0ab02af70d29e6