### PR TITLE
Improve maintenance requirement editing flow

### DIFF
--- a/ProyectoByS/app/src/main/res/layout/activity_register_maintenance_requirements.xml
+++ b/ProyectoByS/app/src/main/res/layout/activity_register_maintenance_requirements.xml
@@ -29,14 +29,6 @@
         android:layout_height="wrap_content"
         android:text="Guardar Requerimientos"
         android:background="@drawable/button_border_red"
-        android:textColor="#000000"/>
-
-    <Button
-        android:id="@+id/btnEditRequirements"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="Editar Requerimientos"
-        android:background="@drawable/button_border_red"
         android:textColor="#000000"
         android:layout_marginTop="16dp"/>
 


### PR DESCRIPTION
## Summary
- simplify maintenance requirement screen by removing the extra button
- load existing requirements when selecting a service
- allow editing and saving from a single button

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68745a3936f88321b48df11e73c4b346