### PR TITLE
Filter technical services in second visit spinner

### DIFF
--- a/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/RegisterSecondVisitActivity.java
+++ b/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/RegisterSecondVisitActivity.java
@@ -41,7 +41,7 @@ public class RegisterSecondVisitActivity extends AppCompatActivity {
         // Configurar base de datos
         databaseHelper = new DatabaseHelper(this);
 
-        // Cargar servicios de mantenimiento
+        // Cargar servicios técnicos
         loadMaintenanceServices();
 
         // Configurar listeners
@@ -60,10 +60,11 @@ public class RegisterSecondVisitActivity extends AppCompatActivity {
     }
 
     private void loadMaintenanceServices() {
-        maintenanceServices = databaseHelper.getAllMaintenanceServices();
+        // Obtener únicamente servicios técnicos próximos
+        maintenanceServices = databaseHelper.getFutureTechnicalServices();
 
         if (maintenanceServices == null || maintenanceServices.isEmpty()) {
-            Toast.makeText(this, "No hay servicios de mantenimiento registrados", Toast.LENGTH_LONG).show();
+            Toast.makeText(this, "No hay servicios técnicos registrados", Toast.LENGTH_LONG).show();
             finish();
             return;
         }

--- a/ProyectoByS/app/src/main/res/layout/activity_register_second_visit.xml
+++ b/ProyectoByS/app/src/main/res/layout/activity_register_second_visit.xml
@@ -15,7 +15,7 @@
         android:layout_gravity="center_horizontal"/>
 
     <TextView
-        android:text="Seleccionar Servicio de Mantenimiento:"
+        android:text="Seleccionar Servicio Técnico:"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"


### PR DESCRIPTION
## Summary
- load technical services for second visit registration
- update UI label to mention technical service

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68745f73238c83218d3697436e9822ab