### PR TITLE
Load only technical services in second visit spinner

### DIFF
--- a/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/DatabaseHelper.java
+++ b/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/DatabaseHelper.java
@@ -525,15 +525,13 @@ public class DatabaseHelper {
 
     // Métodos para manejo de segundas visitas
 
-    // Obtener todos los servicios de mantenimiento (para el spinner)
+    // Obtener solo los servicios técnicos (para el spinner)
     public List<Request> getAllMaintenanceServices() {
         List<Request> list = new ArrayList<>();
         SQLiteDatabase db = helper.getReadableDatabase();
-        
+
         String query = "SELECT id, serviceType, serviceDate, serviceTime, clientCedula, serviceAddress " +
-                       "FROM requests WHERE LOWER(serviceType) LIKE LOWER('%mantenimiento%') OR " +
-                       "LOWER(serviceType) LIKE LOWER('%reparac%') OR " +
-                       "LOWER(serviceType) LIKE LOWER('%técnic%') OR " +
+                       "FROM requests WHERE LOWER(serviceType) LIKE LOWER('%técnic%') OR " +
                        "LOWER(serviceType) LIKE LOWER('%tecnic%') " +
                        "ORDER BY serviceDate DESC, serviceTime DESC";
         


### PR DESCRIPTION
## Summary
- filter technical services only when retrieving services for second visit spinner

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687461162f088321b064cc8a9748e64a