### PR TITLE
Update delete second visit button style

### DIFF
--- a/ProyectoByS/app/src/main/res/drawable/button_red_black.xml
+++ b/ProyectoByS/app/src/main/res/drawable/button_red_black.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="#BD3F3F"/>
+
+    <stroke
+        android:width="2dp"
+        android:color="#000000"/>
+
+    <corners android:radius="12dp"/>
+</shape>

--- a/ProyectoByS/app/src/main/res/layout/activity_register_second_visit.xml
+++ b/ProyectoByS/app/src/main/res/layout/activity_register_second_visit.xml
@@ -115,8 +115,9 @@
             <Button
                 android:id="@+id/btnDeleteSecondVisit"
                 android:text="ELIMINAR"
-                android:background="@drawable/button_red_burgundy"
-                android:textColor="#FFFFFF"
+                android:background="@drawable/button_red_black"
+                android:textColor="#000000"
+                android:elevation="0dp"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"


### PR DESCRIPTION
## Summary
- add `button_red_black` drawable
- use the new drawable in second visit screen with black text
- remove elevation so the delete button has no shadow

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687465cdd9c483219b08c5c19dd5b04a