### PR TITLE
Improve validation message for second visit form

### DIFF
--- a/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/RegisterSecondVisitActivity.java
+++ b/ProyectoByS/app/src/main/java/com/puropoo/proyectobys/RegisterSecondVisitActivity.java
@@ -310,11 +310,7 @@ public class RegisterSecondVisitActivity extends AppCompatActivity {
         }
 
         if (missingFields.length() > 0) {
-            String missingFieldsStr = missingFields.toString();
-            if (missingFieldsStr.endsWith(", ")) {
-                missingFieldsStr = missingFieldsStr.substring(0, missingFieldsStr.length() - 2);
-            }
-            Toast.makeText(this, "Faltan campos obligatorios: " + missingFieldsStr, Toast.LENGTH_LONG).show();
+            Toast.makeText(this, "Por favor complete todos los campos", Toast.LENGTH_SHORT).show();
             return false;
         }
 


### PR DESCRIPTION
## Summary
- update the validation check in `RegisterSecondVisitActivity`
- show a short Toast when trying to save without completing the form

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876b5f4e55083219e1ad26e51173871